### PR TITLE
4회차 과제 - 이나현

### DIFF
--- a/src/main/java/com/example/springsession/controller/TodoController.java
+++ b/src/main/java/com/example/springsession/controller/TodoController.java
@@ -1,0 +1,64 @@
+package com.example.springsession.controller;
+
+
+import com.example.springsession.domain.Todo;
+import com.example.springsession.dto.createTodo;
+import com.example.springsession.dto.patchTodo;
+import com.example.springsession.dto.putTodo;
+import com.example.springsession.service.TodoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/todos")
+public class TodoController {
+    private final TodoService todoService;
+
+    public TodoController(TodoService todoService) {
+        this.todoService = todoService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Todo> create(@RequestBody createTodo createtodo) {
+        Todo newOne = todoService.create(createtodo);
+        return ResponseEntity.ok(newOne);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Todo>> getAll() {
+        return ResponseEntity.ok(todoService.getAll());
+    }
+
+    @GetMapping("/{id}") //개별조회
+    public ResponseEntity<Todo> getById(@PathVariable Long id) {
+        Todo todo = todoService.getById(id);
+        if (todo == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(todo);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Todo> patch(@PathVariable Long id, @RequestBody patchTodo patchtodo) {
+        Todo todo = todoService.patchTodo(id, patchtodo);
+        if(todo == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(todo);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Todo> put(@PathVariable Long id, @RequestBody putTodo puttodo) {
+        Todo todo = todoService.put(id, puttodo);
+        if(todo == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(todo);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Todo> delete(@PathVariable Long id) {
+        Todo todo = todoService.delete(id);
+        if(todo == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(todo);
+    }
+
+
+
+}

--- a/src/main/java/com/example/springsession/controller/TodoController.java
+++ b/src/main/java/com/example/springsession/controller/TodoController.java
@@ -20,24 +20,28 @@ public class TodoController {
         this.todoService = todoService;
     }
 
+    //할일 생성
     @PostMapping
     public ResponseEntity<Todo> create(@RequestBody createTodo createtodo) {
         Todo newOne = todoService.create(createtodo);
         return ResponseEntity.ok(newOne);
     }
 
+    //전체 조회
     @GetMapping
     public ResponseEntity<List<Todo>> getAll() {
         return ResponseEntity.ok(todoService.getAll());
     }
 
-    @GetMapping("/{id}") //개별조회
+    //개별조회
+    @GetMapping("/{id}")
     public ResponseEntity<Todo> getById(@PathVariable Long id) {
         Todo todo = todoService.getById(id);
         if (todo == null) return ResponseEntity.notFound().build();
         return ResponseEntity.ok(todo);
     }
 
+    //patch(일부분만) 수정
     @PatchMapping("/{id}")
     public ResponseEntity<Todo> patch(@PathVariable Long id, @RequestBody patchTodo patchtodo) {
         Todo todo = todoService.patchTodo(id, patchtodo);
@@ -45,6 +49,7 @@ public class TodoController {
         return ResponseEntity.ok(todo);
     }
 
+    //put(덮어쓰기)
     @PutMapping("/{id}")
     public ResponseEntity<Todo> put(@PathVariable Long id, @RequestBody putTodo puttodo) {
         Todo todo = todoService.put(id, puttodo);
@@ -52,6 +57,7 @@ public class TodoController {
         return ResponseEntity.ok(todo);
     }
 
+    //삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<Todo> delete(@PathVariable Long id) {
         Todo todo = todoService.delete(id);

--- a/src/main/java/com/example/springsession/domain/Todo.java
+++ b/src/main/java/com/example/springsession/domain/Todo.java
@@ -1,0 +1,13 @@
+package com.example.springsession.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Todo {
+    private Long id;
+    private String title;
+    private String description;
+    private boolean completed;
+}

--- a/src/main/java/com/example/springsession/dto/createTodo.java
+++ b/src/main/java/com/example/springsession/dto/createTodo.java
@@ -1,0 +1,11 @@
+package com.example.springsession.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class createTodo {
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/example/springsession/dto/patchTodo.java
+++ b/src/main/java/com/example/springsession/dto/patchTodo.java
@@ -1,0 +1,13 @@
+package com.example.springsession.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+//title, description, completed를 위한 부분 수정 dto
+public class patchTodo {
+    private String title;
+    private String description;
+    private Boolean completed;
+}

--- a/src/main/java/com/example/springsession/dto/putTodo.java
+++ b/src/main/java/com/example/springsession/dto/putTodo.java
@@ -1,0 +1,18 @@
+package com.example.springsession.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class putTodo {
+    private String title;
+    private String description;
+    private Boolean completed;
+
+    public boolean checkNull() {
+        boolean answer = true;
+        if(title != null && description != null && completed != null) answer = false;
+        return answer;
+    }
+}

--- a/src/main/java/com/example/springsession/repository/TodoRepository.java
+++ b/src/main/java/com/example/springsession/repository/TodoRepository.java
@@ -1,0 +1,30 @@
+package com.example.springsession.repository;
+
+import com.example.springsession.domain.Todo;
+import com.example.springsession.dto.patchTodo;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class TodoRepository {
+    private final Map<Long, Todo> todoDB = new HashMap<>();
+
+
+    public Todo save(Todo todo) { //저장
+        todoDB.put(todo.getId(), todo);
+        return todo;
+    }
+
+    public List<Todo> findAll() { //전체 값들 조회
+        return new ArrayList<>(todoDB.values());
+    }
+
+    public Todo findById(Long id) { //id로 개별 조회
+        return todoDB.get(id);
+    }
+
+    public void delete(Long id) { //해당 id의 값 삭제
+        todoDB.remove(id);
+    }
+}

--- a/src/main/java/com/example/springsession/service/TodoService.java
+++ b/src/main/java/com/example/springsession/service/TodoService.java
@@ -1,0 +1,73 @@
+package com.example.springsession.service;
+
+import com.example.springsession.domain.Todo;
+import com.example.springsession.dto.createTodo;
+import com.example.springsession.dto.patchTodo;
+import com.example.springsession.dto.putTodo;
+import com.example.springsession.repository.TodoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+public class TodoService {
+    private final TodoRepository todoRepository;
+    private long seq = 0L;
+
+    public TodoService(TodoRepository todoRepository) {
+        this.todoRepository = todoRepository;
+    }
+
+    public Todo create(createTodo newTodo) {
+        Todo todo = new Todo();
+        todo.setId(++seq);
+        todo.setTitle(newTodo.getTitle());
+        todo.setDescription(newTodo.getDescription());
+        todo.setCompleted(false);
+        return todoRepository.save(todo);
+    }
+
+    public List<Todo> getAll() {
+        return todoRepository.findAll();
+    }
+
+    public Todo getById(Long id) {
+        Todo todo = todoRepository.findById(id);
+        return todo;
+    }
+
+    public Todo patchTodo(Long id, patchTodo patchtodo) {
+        Todo change = todoRepository.findById(id);
+        if(change == null) throw new NoSuchElementException("todo 존재하지 않음");
+
+        //부분 수정이니, 값이 null이면 그냥 pass/값이 존재하면 수정
+        if(patchtodo.getTitle() != null) change.setTitle(patchtodo.getTitle());
+        if(patchtodo.getDescription() != null) change.setDescription(patchtodo.getDescription());
+        if(patchtodo.getCompleted() != null) change.setCompleted(patchtodo.getCompleted());
+
+        return change;
+    }
+
+    public Todo put(Long id, putTodo newOne) {
+        Todo todo = todoRepository.findById(id);
+        if (todo == null || newOne.checkNull()) {
+            throw new NoSuchElementException("todo 존재하지 않음");
+        }
+        todo.setTitle(newOne.getTitle());
+        todo.setDescription(newOne.getDescription());
+        todo.setCompleted(newOne.getCompleted());
+        return todoRepository.save(todo);
+    }
+
+    public Todo delete(Long id) {
+        Todo todo = todoRepository.findById(id);
+        if (todo == null) throw new NoSuchElementException("해당 ID의 할 일이 없습니다: " + id);
+
+        todoRepository.delete(id);
+        return todo;
+    }
+
+
+
+}


### PR DESCRIPTION
할 일 생성, 조회, 업데이트, 삭제 기능이 있는 todoList를 구현했습니다.
## 개발한 기능
**todo객체 기반 CRUD api 구현**
`POST/todos`: 할 일 생성
: todo리스트의 제목과 설명을 담아 할 일 생성
`GET/todos`: 전체 할 일 조회
: map에 저장된 전체 할 일을 list 형태로 변환하여 조회
`GET/todos/{id}`: 할 일 개별 조회
: id를 통해서, 해당 id에 저장되어있는 할 일 조회
`PATCH/todos/{id}`: 일부 필드 수정
: 요청에서 전달된 값만 수정. null일 경우 해당 필드는 무시하도록
`PUT/todos/{id}`: 전체 필드 수정
: 전체적인 필드를 수정. -> 하나라도 null이면 안 되므로 putTodo의 checkNull()로 검사
`DELETE/todos/{id}`: 삭제
: 요청받은 id의 할 일을 삭제

## 유의깊게 개발한 부분
1. service와 repository의 계층을 명확하게 구분하는게 좀 어려웠지만, patch와 put등의 비즈니스 로직을 서비스에서 처리할 수 있도록 하였습니다.
2. put은 전체적인 필드를 수정하므로 null이면 안된다는 점을 유의해서 checkNull()을 통해 검사하도록 하였습니다.
3. DTO 계층 분리. 요청 목적에 따라 dto를 구분했습니다.
`createTodo` : 할 일을 생성하려는 목적. **title**과 **description**만 주어지면, id는 자동으로 할당하고 completed는 false로 초기화
`patchTodo` : 일부 필드만 수정하려는 목적. **title, description, completed** 중 수정 가능
`putTodo` : 전체 필드를 수정하려는 목적. **title, description, completed** 전부 받아서 수정
4. 1번과 비슷한 소리지만,, 책임분리가 명확하게 됐으면 좋겠어서 계층을 잘 나누려고 노력했습니다.
5. 저번 과제에서 피드백해주셨던 커밋주기를 최소 기능별로 남겼습니다.

## 의문사항 & 개선사항
1. 개발하다보니, put과 patch가 실제 개발할 때 어떤 상황에서 구분해서 쓰는지 궁금해졌습니다. put은 전체적인 필드가 주어지지 않을 때 오류를 발생하기도 해서 patch보다 활용도가 낮다고 생각하였는데, 꼭 put만을 활용하여 개발을 진행해야하는 것이 있나? 하는 의문사항이 생겼습니다.
2. 초반에 예외처리를 하다보니, service와 controller 두 군데에서 반복적으로 처리하게 되어 로직이 복잡해졌었습니다. (예를 들어 patch예외처리는 service에서 했는데, put은 controller에서 하고... 등등 난잡하게 처리했었습니다 ㅠ) 그 후 코드를 찬찬히 보니 예외처리가 여기저기 흩어져있는걸 보고 service에서 예외를 던지는 방식으로 깔끔하게 처리했는데, 이 방식이 맞는 방식인지 의문이 들었습니다.
-> 찾아보니, 보통 서비스 로직에서 예외를 던지고 컨트롤러는 단순히 호출만 한다고 하더라고요...!! 일단 의문이 들었던 사항이라 적어뒀습니다.
3. 현재 서비스 계층에서 직접 todo 객체를 수정하도록 코드를 짰습니다.(patch부분입니다!) 근데, 보통 도메인이 자기 상태(?)를 수정하고 관리한다고 알고 있고 서비스 계층에선 도메인을 활용해서 흐름을 조절하는 느낌(?)으로 알고 있는데, 서비스계층의 patch부분에서 직접 domain을 수정하고 있어서 계층 처리가 좀 미흡하지 않았나.. 라는 생각을 했습니다. 

## 느낀점
전체적으로 아직까지 계층 분리에 대해 조금 미흡한 것 같습니다. controller, service, domain의 책임이 어떻게 구분되어야하는지 더더 정확히 알아봐야겠다는 생각이 들었습니다.

## 리뷰어에게 전하는 말
시간 내어 리뷰해주셔서 감사합니다. 주신 피드백은 새겨듣고 더 나은 코드를 작성할 수 있도록 노력하겠습니다.
또한 코드 내 의문사항들도 질문해주시면 열심히 답변하겠습니다.

감사합니다!